### PR TITLE
shell.nix: include IOKit on darwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,6 @@ with (import <nixpkgs> {});
 mkShell {
   buildInputs = [
     nodejs-16_x
-    yarn
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     IOKit
   ]);


### PR DESCRIPTION
Needed for building the node-gyp dependency.