### PR TITLE
Add GitHub Action to bump npm version number

### DIFF
--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -1,0 +1,39 @@
+name: Bump npm package version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to bump
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Bump version
+        id: bump
+        run: |
+          version="$(npm version --no-commit-hooks --no-git-tag-version ${{ inputs.version }})"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:          
+          assignees: ${{ github.actor }}
+          branch: "version/${{ steps.bump.outputs.version }}"
+          delete-branch: true
+          title: "Bump version to ${{ steps.bump.outputs.version }}"


### PR DESCRIPTION
This will generate a PR with the changes made by running `npm version <version type>` and assign it to whomever triggered the workflow.