### PR TITLE
Add --signer=raw to print raw transactions

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -54,7 +54,7 @@ export abstract class TransactionCommand extends BlockchainCommand {
 
   async catch(error: CommandError | TxError): Promise<void> {
     if (!process.env.DEBUG && "error" in error && "reason" in error.error) {
-      console.log(error.error.reason);
+      this.error(error.error.reason);
     } else {
       throw error;
     }

--- a/src/commands/bundle/checksum.ts
+++ b/src/commands/bundle/checksum.ts
@@ -7,9 +7,12 @@ export default class BundleChecksum extends Command {
   static examples = ["<%= config.bin %> <%= command.id %> my-site-v1.0.0.tgz"];
   static usage = "<%= command.id %> FILE";
   static args: Arg[] = [{ name: "FILE", description: "The file to checksum.", required: true }];
+  static enableJsonFlag = true;
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(BundleChecksum);
-    console.log(await sha256File(args.FILE));
+    const sha = await sha256File(args.FILE);
+    this.log(sha);
+    return sha;
   }
 }

--- a/src/commands/bundle/create.ts
+++ b/src/commands/bundle/create.ts
@@ -8,17 +8,19 @@ export default class BundleCreate extends Command {
   static description = "Bundle an application for use on the Armada Network.";
   static examples = ["<%= config.bin %> <%= command.id %> my-site-v1.0.0 ./dist"];
   static usage = "<%= command.id %> NAME DIR";
+  static enableJsonFlag = true;
   static args: Arg[] = [
     { name: "NAME", description: "The name of the bundle to create (e.g. my-site-v1.0.0).", required: true },
     { name: "DIR", description: "Relative path to the app's build directory (e.g. ./dist).", required: true },
   ];
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(BundleCreate);
     await generateManifest(args.DIR);
     const bundleName = normalizeBundleExtension(args.NAME);
     await compress(bundleName, args.DIR);
-    console.log(bundleName);
+    this.log(bundleName);
+    return bundleName;
   }
 }
 

--- a/src/commands/bundle/manifest.ts
+++ b/src/commands/bundle/manifest.ts
@@ -6,14 +6,16 @@ export default class BundleManifest extends Command {
   static description = "Generate a new site manifest.";
   static examples = ["<%= config.bin %> <%= command.id %> ./dist"];
   static usage = "<%= command.id %> DIR";
+  static enableJsonFlag = true;
   static hidden = true;
   static args: Arg[] = [
     { name: "DIR", description: "Relative path to the app's build directory (e.g. ./dist).", required: true },
   ];
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(BundleManifest);
     const manifestPath = await generateManifest(args.DIR);
-    console.log(manifestPath);
+    this.log(manifestPath);
+    return manifestPath;
   }
 }

--- a/src/commands/escrow/withdraw.ts
+++ b/src/commands/escrow/withdraw.ts
@@ -1,8 +1,7 @@
-import { CliUx } from "@oclif/core";
 import { Arg } from "@oclif/core/lib/interfaces";
 import { parseUnits } from "ethers/lib/utils";
 import { TransactionCommand } from "../../base";
-import { decodeEvent, getContract, getSigner, getTxUrl, normalizeHash, normalizeRecord } from "../../helpers";
+import { getContract, getSigner, normalizeHash, pretty, run } from "../../helpers";
 
 export default class EscrowWithdraw extends TransactionCommand {
   static description = "Withdraw Armada tokens from project escrow.\nThe tokens are sent to the project owner.";
@@ -14,23 +13,16 @@ export default class EscrowWithdraw extends TransactionCommand {
     { name: "TOKENS", description: "The Armada token amount to withdraw (e.g. 1.0).", required: true },
   ];
 
-  public async run(): Promise<Record<string, unknown>> {
+  public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(EscrowWithdraw);
     const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = normalizeHash(args.ID);
     const tokens = parseUnits(args.TOKENS, 18);
     if (tokens.lte(0)) this.error("Positive amount required.");
-    CliUx.ux.action.start("- Submitting transaction");
-    const tx = await projects.withdrawProjectEscrow(projectId, tokens);
-    CliUx.ux.action.stop("done");
-    this.log(`> ${getTxUrl(tx)}`);
-    CliUx.ux.action.start("- Processing transaction");
-    const receipt = await tx.wait();
-    CliUx.ux.action.stop("done");
-    const event = await decodeEvent(receipt, projects, "ProjectEscrowChanged");
-    const output = normalizeRecord(event);
-    if (!flags.json) console.log(output);
+    const tx = await projects.populateTransaction.withdrawProjectEscrow(projectId, tokens);
+    const output = await run(tx, signer, [projects]);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/commands/key/delete.ts
+++ b/src/commands/key/delete.ts
@@ -9,8 +9,9 @@ export default class KeyDelete extends Command {
   static examples = ["<%= config.bin %> <%= command.id %> 0x123abc..."];
   static usage = "<%= command.id %>";
   static args: Arg[] = [{ name: "ADDR", description: "The address of the key to delete." }];
+  static enableJsonFlag = true;
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(KeyDelete);
     if (!args.ADDR) {
       const wallets = await listWallets();
@@ -34,6 +35,7 @@ export default class KeyDelete extends Command {
     const address = args.ADDR;
     await deleteWallet(address);
     await keytar.deletePassword("armada-cli", address);
-    console.log(`Account ${address} deleted`);
+    this.log(`Account ${address} deleted`);
+    return address;
   }
 }

--- a/src/commands/key/edit.ts
+++ b/src/commands/key/edit.ts
@@ -1,18 +1,19 @@
 import { Command } from "@oclif/core";
 import { Arg } from "@oclif/core/lib/interfaces";
 import inquirer from "inquirer";
-import { listWallets, loadWallet, readWallet, updateWallet } from "../../keystore";
+import { listWallets, readWallet, updateWallet } from "../../keystore";
 
 export default class KeyEdit extends Command {
   static description = "Changes the optional key description.";
   static examples = ["<%= config.bin %> <%= command.id %>"];
   static usage = "<%= command.id %>";
+  static enableJsonFlag = true;
   static args: Arg[] = [
     { name: "ADDR", description: "The address of the key to describe." },
     { name: "DESC", description: "The new description for the key." },
   ];
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     const { args } = await this.parse(KeyEdit);
     if (!!args.ADDR !== !!args.DESC) {
       this.error("ADDR and DESC must be specified together");
@@ -47,6 +48,7 @@ export default class KeyEdit extends Command {
 
     const address = args.ADDR;
     await updateWallet(address, args.DESC);
-    console.log(`Account ${address} updated`);
+    this.log(`Account ${address} updated`);
+    return address;
   }
 }

--- a/src/commands/key/import.ts
+++ b/src/commands/key/import.ts
@@ -6,8 +6,9 @@ export default class KeyImport extends Command {
   static description = "Saves a private key for signing transactions.\nThe keys are stored in an encrypted keystore.";
   static examples = ["<%= config.bin %> <%= command.id %>"];
   static usage = "<%= command.id %>";
+  static enableJsonFlag = true;
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     await this.parse(KeyImport);
     const responses = await inquirer.prompt([
       { name: "privateKey", message: "Paste the private key to import:", type: "password", mask: "*" },
@@ -17,6 +18,7 @@ export default class KeyImport extends Command {
 
     const address = await saveWallet(responses.privateKey, responses.password, responses.description);
     await loadWallet(address, responses.password);
-    console.log(`Account ${address} imported`);
+    this.log(`Account ${address} imported`);
+    return address;
   }
 }

--- a/src/commands/key/list.ts
+++ b/src/commands/key/list.ts
@@ -5,13 +5,15 @@ export default class KeyList extends Command {
   static description = "Lists keys saved in the encrypted keystore.";
   static examples = ["<%= config.bin %> <%= command.id %>"];
   static usage = "<%= command.id %>";
+  static enableJsonFlag = true;
 
-  public async run(): Promise<void> {
+  public async run(): Promise<unknown> {
     await this.parse(KeyList);
     const wallets = await listWallets();
     for (let i = 0; i < wallets.length; ++i) {
       const w = wallets[i];
-      console.log(w.description ? `${w.address} - ${w.description}` : w.address);
+      this.log(w.description ? `${w.address} - ${w.description}` : w.address);
     }
+    return wallets;
   }
 }

--- a/src/commands/node/list.ts
+++ b/src/commands/node/list.ts
@@ -2,7 +2,7 @@ import { HashZero } from "@ethersproject/constants";
 import { Flags } from "@oclif/core";
 import { Result } from "ethers/lib/utils";
 import { BlockchainCommand } from "../../base";
-import { getAll, getContract, getProvider, normalizeHash, normalizeRecords } from "../../helpers";
+import { getAll, getContract, getProvider, normalizeHash, normalizeRecords, pretty } from "../../helpers";
 
 export default class NodeList extends BlockchainCommand {
   static description = "List content nodes on the Armada Network.";
@@ -45,7 +45,7 @@ export default class NodeList extends BlockchainCommand {
 
     const records = results.slice(flags.skip, flags.skip + flags.size);
     const output = normalizeRecords(records);
-    if (!flags.json) console.log(output);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/commands/node/show.ts
+++ b/src/commands/node/show.ts
@@ -1,6 +1,6 @@
 import { Arg } from "@oclif/core/lib/interfaces";
 import { BlockchainCommand } from "../../base";
-import { getContract, getProvider, normalizeHash, normalizeRecord } from "../../helpers";
+import { getContract, getProvider, normalizeHash, normalizeRecord, pretty } from "../../helpers";
 
 export default class NodeShow extends BlockchainCommand {
   static description = "Show details of an Armada Network node.";
@@ -15,7 +15,7 @@ export default class NodeShow extends BlockchainCommand {
     const nodeId = normalizeHash(args.ID);
     const record = await nodes.getNode(nodeId);
     const output = normalizeRecord(record);
-    if (!flags.json) console.log(output);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/commands/project/delete.ts
+++ b/src/commands/project/delete.ts
@@ -1,7 +1,6 @@
-import { CliUx } from "@oclif/core";
 import { Arg } from "@oclif/core/lib/interfaces";
 import { TransactionCommand } from "../../base";
-import { decodeEvent, getContract, getSigner, getTxUrl, normalizeHash, normalizeRecord } from "../../helpers";
+import { getContract, getSigner, normalizeHash, pretty, run } from "../../helpers";
 
 export default class ProjectDelete extends TransactionCommand {
   static description = "Delete a project from the Armada Network.";
@@ -9,21 +8,14 @@ export default class ProjectDelete extends TransactionCommand {
   static usage = "<%= command.id %> ID";
   static args: Arg[] = [{ name: "ID", description: "The ID of the project to delete.", required: true }];
 
-  public async run(): Promise<Record<string, unknown>> {
+  public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ProjectDelete);
     const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = normalizeHash(args.ID);
-    CliUx.ux.action.start("- Submitting transaction");
-    const tx = await projects.deleteProject(projectId);
-    CliUx.ux.action.stop("done");
-    this.log(`> ${getTxUrl(tx)}`);
-    CliUx.ux.action.start("- Processing transaction");
-    const receipt = await tx.wait();
-    CliUx.ux.action.stop("done");
-    const event = await decodeEvent(receipt, projects, "ProjectDeleted");
-    const output = normalizeRecord(event);
-    if (!flags.json) console.log(output);
+    const tx = await projects.populateTransaction.deleteProject(projectId);
+    const output = await run(tx, signer, [projects]);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -1,7 +1,7 @@
 import { Flags } from "@oclif/core";
 import { Result } from "ethers/lib/utils";
 import { BlockchainCommand } from "../../base";
-import { getAll, getContract, getProvider, normalizeAddress, normalizeRecords } from "../../helpers";
+import { getAll, getContract, getProvider, normalizeAddress, normalizeRecords, pretty } from "../../helpers";
 
 export default class ProjectList extends BlockchainCommand {
   static description = "List projects on the Armada Network.";
@@ -28,7 +28,7 @@ export default class ProjectList extends BlockchainCommand {
     }
 
     const output = normalizeRecords(results.slice(flags.skip, flags.skip + flags.size));
-    if (!flags.json) console.log(output);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/commands/project/show.ts
+++ b/src/commands/project/show.ts
@@ -1,6 +1,6 @@
 import { Arg } from "@oclif/core/lib/interfaces";
 import { BlockchainCommand } from "../../base";
-import { getContract, getProvider, normalizeHash, normalizeRecord } from "../../helpers";
+import { getContract, getProvider, normalizeHash, normalizeRecord, pretty } from "../../helpers";
 
 export default class ProjectShow extends BlockchainCommand {
   static description = "Show details of an Armada Network project.";
@@ -15,7 +15,7 @@ export default class ProjectShow extends BlockchainCommand {
     const projectId = normalizeHash(args.ID);
     const record = await projects.getProject(projectId);
     const output = normalizeRecord(record);
-    if (!flags.json) console.log(output);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/commands/reservation/list.ts
+++ b/src/commands/reservation/list.ts
@@ -2,7 +2,7 @@ import { Flags } from "@oclif/core";
 import { Arg } from "@oclif/core/lib/interfaces";
 import { Result } from "ethers/lib/utils";
 import { BlockchainCommand } from "../../base";
-import { getAll, getContract, getProvider, normalizeHash, normalizeRecords } from "../../helpers";
+import { getAll, getContract, getProvider, normalizeHash, normalizeRecords, pretty } from "../../helpers";
 
 export default class ReservationList extends BlockchainCommand {
   static description = "List node reservations by a project.";
@@ -26,7 +26,7 @@ export default class ReservationList extends BlockchainCommand {
     });
 
     const output = normalizeRecords(results.slice(flags.skip, flags.skip + flags.size));
-    if (!flags.json) console.log(output);
+    this.log(pretty(output));
     return output;
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { inspect } from "util";
 import type { Provider, TransactionReceipt } from "@ethersproject/abstract-provider";
 import { AddressZero, HashZero } from "@ethersproject/constants";
 import { CliUx } from "@oclif/core";
@@ -43,9 +44,8 @@ export const Permit: Record<string, Array<TypedDataField>> = {
   ],
 };
 
-// Pretty prints the value as a string with proper formatting and indentation.
 export function pretty(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value, null, "  ");
+  return typeof value === "string" ? value : inspect(value);
 }
 
 // Signs and executes the transaction and returns its emitted events, if a signer is provided.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -60,18 +60,18 @@ export async function run(
     delete tx.from; // Raw tx must have "from" field
     const raw = ethers.utils.serializeTransaction(tx);
     return raw;
-  } else {
-    CliUx.ux.action.start("- Submitting transaction");
-    const response = await signer.sendTransaction(tx);
-    CliUx.ux.action.stop("done");
-    // Use stderr to not interfere with --json flag
-    console.warn(`> ${getTxUrl(response)}`);
-    CliUx.ux.action.start("- Processing transaction");
-    const receipt = await response.wait();
-    CliUx.ux.action.stop("done");
-    const events = await decodeEvents(receipt, contracts);
-    return events;
   }
+
+  CliUx.ux.action.start("- Submitting transaction");
+  const response = await signer.sendTransaction(tx);
+  CliUx.ux.action.stop("done");
+  // Use stderr to not interfere with --json flag
+  console.warn(`> ${getTxUrl(response)}`);
+  CliUx.ux.action.start("- Processing transaction");
+  const receipt = await response.wait();
+  CliUx.ux.action.stop("done");
+  const events = await decodeEvents(receipt, contracts);
+  return events;
 }
 
 export function getTxUrl(tx: Transaction): string {


### PR DESCRIPTION
Also:
- Convert all remaining commands to support --json flag
- Remove all uses of console.log() for better --json support
- Changed tx event decoding to display all relevant events

The last point means that the cli will now always print out an array of event structs instead of a single event struct.