### PR TITLE
Adding support for Ledger address derivations

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -44,6 +44,16 @@ export abstract class TransactionCommand extends BlockchainCommand {
       default: "keystore",
       exclusive: ["address", "key"],
     }),
+    account: Flags.string({
+      helpGroup: "BASE",
+      description: "Account derivation number if using Ledger, starts at 0.",
+      helpValue: "ACCOUNT",
+      exclusive: ["address", "key"],
+      default: "0",
+      relationships: [
+        { type: "all", flags: [{ name: "signer", when: async (flags) => flags["signer"] === "ledger" }] },
+      ],
+    }),
     key: Flags.string({
       helpGroup: "BASE",
       description: "The private key for transactions (danger).",

--- a/src/base.ts
+++ b/src/base.ts
@@ -47,7 +47,7 @@ export abstract class TransactionCommand extends BlockchainCommand {
     account: Flags.string({
       helpGroup: "BASE",
       description: "Account derivation number if using Ledger, starts at 0.",
-      helpValue: "ACCOUNT",
+      helpValue: "N",
       exclusive: ["address", "key"],
       default: "0",
       relationships: [

--- a/src/commands/node/create.ts
+++ b/src/commands/node/create.ts
@@ -65,7 +65,7 @@ export default class NodeCreate extends TransactionCommand {
       })
     );
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const nodes = await getContract(flags.network, flags.abi, "ArmadaNodes", signer);
     const tx = await nodes.populateTransaction.createNodes(operatorId, false, records);
     const output = await run(tx, signer, [nodes]);

--- a/src/commands/node/delete.ts
+++ b/src/commands/node/delete.ts
@@ -16,7 +16,7 @@ export default class NodeDelete extends TransactionCommand {
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(NodeDelete);
     const nodeIds = args.IDS.split(",").map((id: string) => normalizeHash(id));
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const nodes = await getContract(flags.network, flags.abi, "ArmadaNodes", signer);
     const operatorId = (await nodes.getNode(nodeIds[0])).operatorId;
     const tx = await nodes.populateTransaction.deleteNodes(operatorId, false, nodeIds);

--- a/src/commands/node/enable.ts
+++ b/src/commands/node/enable.ts
@@ -20,7 +20,7 @@ export default class NodeEnable extends TransactionCommand {
       this.error("Must provide a true or false.");
     }
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const nodes = await getContract(flags.network, flags.abi, "ArmadaNodes", signer);
     const nodeIds = args.IDS.split(",").map((id: string) => normalizeHash(id));
     const disables = nodeIds.map(() => args.BOOL !== "true");

--- a/src/commands/node/host.ts
+++ b/src/commands/node/host.ts
@@ -52,7 +52,7 @@ export default class NodeHost extends TransactionCommand {
       })
     );
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const nodes = await getContract(flags.network, flags.abi, "ArmadaNodes", signer);
     const nodeIds = records.map((r) => r.nodeId);
     const hosts = records.map((r) => r.host);

--- a/src/commands/node/price.ts
+++ b/src/commands/node/price.ts
@@ -56,7 +56,7 @@ export default class NodePrice extends TransactionCommand {
       })
     );
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const nodes = await getContract(flags.network, flags.abi, "ArmadaNodes", signer);
     const nodeIds = records.map((r) => r.nodeId);
     const prices = records.map((r) => r.price);

--- a/src/commands/operator/deposit.ts
+++ b/src/commands/operator/deposit.ts
@@ -14,7 +14,7 @@ export default class OperatorDeposit extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(OperatorDeposit);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const token = await getContract(flags.network, flags.abi, "ArmadaToken", signer);
     const operators = await getContract(flags.network, flags.abi, "ArmadaOperators", signer);
     const address = await signer.getAddress();

--- a/src/commands/operator/owner.ts
+++ b/src/commands/operator/owner.ts
@@ -14,7 +14,7 @@ export default class OperatorOwner extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(OperatorOwner);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const operators = await getContract(flags.network, flags.abi, "ArmadaOperators", signer);
     const operatorId = normalizeHash(args.ID);
     const tx = await operators.populateTransaction.setOperatorOwner(operatorId, args.ADDR);

--- a/src/commands/operator/props.ts
+++ b/src/commands/operator/props.ts
@@ -14,7 +14,7 @@ export default class OperatorProps extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(OperatorProps);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const operators = await getContract(flags.network, flags.abi, "ArmadaOperators", signer);
     const operatorId = normalizeHash(args.ID);
     const tx = await operators.populateTransaction.setOperatorProps(operatorId, args.NAME, args.EMAIL);

--- a/src/commands/operator/withdraw.ts
+++ b/src/commands/operator/withdraw.ts
@@ -17,7 +17,7 @@ export default class OperatorWithdraw extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(OperatorWithdraw);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const token = await getContract(flags.network, flags.abi, "ArmadaToken", signer);
     const operators = await getContract(flags.network, flags.abi, "ArmadaOperators", signer);
     const address = await signer.getAddress();

--- a/src/commands/project/content.ts
+++ b/src/commands/project/content.ts
@@ -22,7 +22,7 @@ export default class ProjectContent extends TransactionCommand {
       this.error("Must provide both URL and SHA.");
     }
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = normalizeHash(args.ID);
     const bundleSha = normalizeHash(args.SHA);

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -23,7 +23,7 @@ export default class ProjectCreate extends TransactionCommand {
       this.error("Can only specify URL and SHA together.");
     }
 
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const owner = flags.owner ? normalizeAddress(flags.owner) : await signer.getAddress();
     const bundleSha = normalizeHash(args.SHA);

--- a/src/commands/project/delete.ts
+++ b/src/commands/project/delete.ts
@@ -10,7 +10,7 @@ export default class ProjectDelete extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ProjectDelete);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = normalizeHash(args.ID);
     const tx = await projects.populateTransaction.deleteProject(projectId);

--- a/src/commands/project/deposit.ts
+++ b/src/commands/project/deposit.ts
@@ -14,7 +14,7 @@ export default class ProjectDeposit extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ProjectDeposit);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const token = await getContract(flags.network, flags.abi, "ArmadaToken", signer);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const address = await signer.getAddress();

--- a/src/commands/project/owner.ts
+++ b/src/commands/project/owner.ts
@@ -14,7 +14,7 @@ export default class ProjectOwner extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ProjectOwner);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = normalizeHash(args.ID);
     const tx = await projects.populateTransaction.setProjectOwner(projectId, args.ADDR);

--- a/src/commands/project/props.ts
+++ b/src/commands/project/props.ts
@@ -14,7 +14,7 @@ export default class ProjectProps extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ProjectProps);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = normalizeHash(args.ID);
     const tx = await projects.populateTransaction.setProjectProps(projectId, args.NAME, args.EMAIL);

--- a/src/commands/project/withdraw.ts
+++ b/src/commands/project/withdraw.ts
@@ -17,7 +17,7 @@ export default class ProjectWithdraw extends TransactionCommand {
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ProjectWithdraw);
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const token = await getContract(flags.network, flags.abi, "ArmadaToken", signer);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const address = await signer.getAddress();

--- a/src/commands/reservation/create.ts
+++ b/src/commands/reservation/create.ts
@@ -29,7 +29,7 @@ export default class ReservationCreate extends TransactionCommand {
     }
 
     const nodeIds = args.IDS.split(",").map((id: string) => normalizeHash(id));
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const reservations = await getContract(flags.network, flags.abi, "ArmadaReservations", signer);
     const projectId = normalizeHash(args.ID);
     const prices = nodeIds.map(() => parseUnits("1", 18));

--- a/src/commands/reservation/delete.ts
+++ b/src/commands/reservation/delete.ts
@@ -15,7 +15,7 @@ export default class ReservationDelete extends TransactionCommand {
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ReservationDelete);
     const nodeIds = args.IDS.split(",").map((id: string) => normalizeHash(id));
-    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const reservations = await getContract(flags.network, flags.abi, "ArmadaReservations", signer);
     const projectId = normalizeHash(args.ID);
     const slot = { last: false, next: true };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -184,7 +184,8 @@ export async function getSigner(
   rpcUrl: string | undefined,
   address: string | undefined,
   signer: SignerType,
-  privateKey: string | undefined
+  privateKey: string | undefined,
+  account: string | "0"
 ): Promise<Signer> {
   const url = rpcUrl ?? Networks[network].url;
   const provider = new ethers.providers.JsonRpcProvider(url);
@@ -195,7 +196,7 @@ export async function getSigner(
   } else if (signer === "ledger") {
     // Use stderr to not interfere with --json flag
     console.warn("> Make sure the Ledger wallet is unlocked and the Ethereum application is open");
-    wallet = new LedgerSigner(provider);
+    wallet = new LedgerSigner(provider, "default", account);
     const address = await wallet.getAddress();
     // Use stderr to not interfere with --json flag
     console.warn(`> Using Ledger wallet ${address}`);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -185,7 +185,7 @@ export async function getSigner(
   address: string | undefined,
   signer: SignerType,
   privateKey: string | undefined,
-  account: string | "0"
+  account: string | undefined
 ): Promise<Signer> {
   const url = rpcUrl ?? Networks[network].url;
   const provider = new ethers.providers.JsonRpcProvider(url);
@@ -196,6 +196,9 @@ export async function getSigner(
   } else if (signer === "ledger") {
     // Use stderr to not interfere with --json flag
     console.warn("> Make sure the Ledger wallet is unlocked and the Ethereum application is open");
+    if (!account) {
+      account = "0";
+    }
     wallet = new LedgerSigner(provider, "default", account);
     const address = await wallet.getAddress();
     // Use stderr to not interfere with --json flag

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -47,8 +47,6 @@ export const transports: { [name: string]: TransportCreator } = Object.freeze({
   default: hidWrapper,
 });
 
-const defaultPath = "m/44'/60'/0'/0/0";
-
 function waiter(duration: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, duration);
@@ -57,18 +55,19 @@ function waiter(duration: number): Promise<void> {
 
 export class LedgerSigner extends ethers.Signer {
   readonly type: string;
-  readonly path: string;
+  readonly account: string;
 
   readonly _eth: Promise<Eth>;
 
-  constructor(provider?: ethers.providers.Provider, type?: string, path?: string) {
+  constructor(provider?: ethers.providers.Provider, type?: string, account?: string) {
     super();
-    if (path == null) {
-      path = defaultPath;
+    if (account == null) {
+      account = "0";
     }
     if (type == null) {
       type = "default";
     }
+    const path = `m/44'/60'/${account}'/0/0`;
 
     ethers.utils.defineReadOnly(this, "path", path);
     ethers.utils.defineReadOnly(this, "type", type);


### PR DESCRIPTION
[Ledger supports BIP44](https://github.com/LedgerHQ/ledger-live/wiki/LLC:derivation) which allows multiple derived Ethereum addresses from the same private key.

Added a CLI flag `--account`, dependent on the signer set to `ledger`, that allows users to select which derived account to use from their Ledger. The default account is 0 which is what the default path was originally set at.

Could probably make this a bit more interactive, but this will do for now.