### PR TITLE
Update ArmadaProjects ABI to include metadata

### DIFF
--- a/abi/staging/ArmadaProjects.json
+++ b/abi/staging/ArmadaProjects.json
@@ -76,6 +76,12 @@
           "internalType": "bytes32",
           "name": "checksum",
           "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
         }
       ],
       "name": "ProjectCreated",
@@ -119,6 +125,12 @@
           "internalType": "bytes32",
           "name": "checksum",
           "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
         }
       ],
       "name": "ProjectDeleted",
@@ -147,6 +159,31 @@
         }
       ],
       "name": "ProjectEscrowChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "projectId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "oldMetadata",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "newMetadata",
+          "type": "string"
+        }
+      ],
+      "name": "ProjectMetadataChanged",
       "type": "event"
     },
     {

--- a/abi/staging/ArmadaProjects.json
+++ b/abi/staging/ArmadaProjects.json
@@ -239,6 +239,11 @@
               "internalType": "bytes32",
               "name": "checksum",
               "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
             }
           ],
           "internalType": "struct ArmadaCreateProjectData",
@@ -339,6 +344,24 @@
           "type": "bytes32"
         },
         {
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
+        }
+      ],
+      "name": "setProjectMetadata",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "projectId",
+          "type": "bytes32"
+        },
+        {
           "internalType": "address",
           "name": "owner",
           "type": "address"
@@ -423,6 +446,11 @@
               "internalType": "bytes32",
               "name": "checksum",
               "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
             }
           ],
           "internalType": "struct ArmadaProject",
@@ -489,6 +517,11 @@
               "internalType": "bytes32",
               "name": "checksum",
               "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
             }
           ],
           "internalType": "struct ArmadaProject[]",

--- a/abi/testnet/ArmadaProjects.json
+++ b/abi/testnet/ArmadaProjects.json
@@ -76,6 +76,12 @@
           "internalType": "bytes32",
           "name": "checksum",
           "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
         }
       ],
       "name": "ProjectCreated",
@@ -119,6 +125,12 @@
           "internalType": "bytes32",
           "name": "checksum",
           "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
         }
       ],
       "name": "ProjectDeleted",
@@ -147,6 +159,31 @@
         }
       ],
       "name": "ProjectEscrowChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "projectId",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "oldMetadata",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "newMetadata",
+          "type": "string"
+        }
+      ],
+      "name": "ProjectMetadataChanged",
       "type": "event"
     },
     {

--- a/abi/testnet/ArmadaProjects.json
+++ b/abi/testnet/ArmadaProjects.json
@@ -239,6 +239,11 @@
               "internalType": "bytes32",
               "name": "checksum",
               "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
             }
           ],
           "internalType": "struct ArmadaCreateProjectData",
@@ -339,6 +344,24 @@
           "type": "bytes32"
         },
         {
+          "internalType": "string",
+          "name": "metadata",
+          "type": "string"
+        }
+      ],
+      "name": "setProjectMetadata",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "projectId",
+          "type": "bytes32"
+        },
+        {
           "internalType": "address",
           "name": "owner",
           "type": "address"
@@ -423,6 +446,11 @@
               "internalType": "bytes32",
               "name": "checksum",
               "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
             }
           ],
           "internalType": "struct ArmadaProject",
@@ -489,6 +517,11 @@
               "internalType": "bytes32",
               "name": "checksum",
               "type": "bytes32"
+            },
+            {
+              "internalType": "string",
+              "name": "metadata",
+              "type": "string"
             }
           ],
           "internalType": "struct ArmadaProject[]",

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -7,12 +7,13 @@ import { getContract, getSigner, parseAddress, parseHash, pretty, run } from "..
 export default class ProjectCreate extends TransactionCommand {
   static summary = "Register a new project on the Armada Network.";
   static examples = ['<%= config.bin %> <%= command.id %> "My Project" notify@myproject.com'];
-  static usage = "<%= command.id %> [--owner ADDR] NAME EMAIL [URL] [SHA]";
+  static usage = "<%= command.id %> [--owner ADDR] NAME EMAIL [URL] [SHA] [METADATA]";
   static args: Arg[] = [
     { name: "NAME", description: "The human readable name of the new project.", required: true },
     { name: "EMAIL", description: "The project email for admin notifications.", required: true },
     { name: "URL", description: "The public URL to fetch the content bundle.", default: "" },
     { name: "SHA", description: "The SHA-256 checksum of the content bundle.", default: "" },
+    { name: "METADATA", description: "Optional JSON.stringified metadata to attach to this project.", default: "" },
   ];
   static flags = {
     owner: Flags.string({ description: "[default: caller] The owner for the new project.", helpValue: "ADDR" }),
@@ -31,7 +32,14 @@ export default class ProjectCreate extends TransactionCommand {
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const owner = flags.owner ? parseAddress(flags.owner) : await signer.getAddress();
     const bundleSha = parseHash(args.SHA);
-    const tx = await projects.populateTransaction.createProject([owner, args.NAME, args.EMAIL, args.URL, bundleSha]);
+    const tx = await projects.populateTransaction.createProject([
+      owner,
+      args.NAME,
+      args.EMAIL,
+      args.URL,
+      bundleSha,
+      args.METADATA,
+    ]);
     const output = await run(tx, signer, [projects]);
     this.log(pretty(output));
     return output;

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -13,7 +13,7 @@ export default class ProjectCreate extends TransactionCommand {
     { name: "EMAIL", description: "The project email for admin notifications.", required: true },
     { name: "URL", description: "The public URL to fetch the content bundle.", default: "" },
     { name: "SHA", description: "The SHA-256 checksum of the content bundle.", default: "" },
-    { name: "METADATA", description: "Optional JSON.stringified metadata to attach to this project.", default: "" },
+    { name: "METADATA", description: "JSON metadata to attach to this project.", default: "" },
   ];
   static flags = {
     owner: Flags.string({ description: "[default: caller] The owner for the new project.", helpValue: "ADDR" }),

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -13,7 +13,7 @@ export default class ProjectCreate extends TransactionCommand {
     { name: "EMAIL", description: "The project email for admin notifications.", required: true },
     { name: "URL", description: "The public URL to fetch the content bundle.", default: "" },
     { name: "SHA", description: "The SHA-256 checksum of the content bundle.", default: "" },
-    { name: "METADATA", description: "JSON metadata to attach to this project.", default: "" },
+    { name: "METADATA", description: "JSON metadata string to attach to this project.", default: "" },
   ];
   static flags = {
     owner: Flags.string({ description: "[default: caller] The owner for the new project.", helpValue: "ADDR" }),
@@ -32,6 +32,13 @@ export default class ProjectCreate extends TransactionCommand {
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const owner = flags.owner ? parseAddress(flags.owner) : await signer.getAddress();
     const bundleSha = parseHash(args.SHA);
+    if (args.METADATA !== "") {
+      try {
+        JSON.parse(args.METADATA);
+      } catch (e) {
+        this.error("METADATA must be valid JSON.");
+      }
+    }
     const tx = await projects.populateTransaction.createProject([
       owner,
       args.NAME,

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -13,7 +13,7 @@ export default class ProjectCreate extends TransactionCommand {
     { name: "EMAIL", description: "The project email for admin notifications.", required: true },
     { name: "URL", description: "The public URL to fetch the content bundle.", default: "" },
     { name: "SHA", description: "The SHA-256 checksum of the content bundle.", default: "" },
-    { name: "METADATA", description: "JSON metadata string to attach to this project.", default: "" },
+    { name: "METADATA", description: "JSON metadata to attach to this project.", default: "" },
   ];
   static flags = {
     owner: Flags.string({ description: "[default: caller] The owner for the new project.", helpValue: "ADDR" }),

--- a/src/commands/project/metadata.ts
+++ b/src/commands/project/metadata.ts
@@ -10,7 +10,7 @@ export default class ProjectMetadata extends TransactionCommand {
     { name: "ID", description: "The ID of the project to change metadata.", required: true },
     {
       name: "METADATA",
-      description: "New JSON metadata string to attach to the project. Previous metadata will be overwritten.",
+      description: "New JSON metadata. Previous metadata will be overwritten.",
       required: true,
     },
   ];

--- a/src/commands/project/metadata.ts
+++ b/src/commands/project/metadata.ts
@@ -4,7 +4,7 @@ import { getContract, getSigner, parseHash, pretty, run } from "../../helpers";
 
 export default class ProjectMetadata extends TransactionCommand {
   static summary = "Set metadata property on a project.";
-  static examples = ['<%= config.bin %> <%= command.id %> \'{"property": "value"}\''];
+  static examples = ['<%= config.bin %> <%= command.id %> 0x123abc... \'{"property": "value"}\''];
   static usage = "<%= command.id %> ID METADATA";
   static args: Arg[] = [
     { name: "ID", description: "The ID of the project to change metadata.", required: true },

--- a/src/commands/project/metadata.ts
+++ b/src/commands/project/metadata.ts
@@ -1,0 +1,28 @@
+import { Arg } from "@oclif/core/lib/interfaces";
+import { TransactionCommand } from "../../base";
+import { getContract, getSigner, parseHash, pretty, run } from "../../helpers";
+
+export default class ProjectMetadata extends TransactionCommand {
+  static summary = "Set metadata property on a project.";
+  static examples = ['<%= config.bin %> <%= command.id %> \'{"property": "value"}\''];
+  static usage = "<%= command.id %> ID METADATA";
+  static args: Arg[] = [
+    { name: "ID", description: "The ID of the project to change metadata.", required: true },
+    {
+      name: "METADATA",
+      description: "Optional JSON.stringified metadata to attach to this project.",
+      required: true,
+    },
+  ];
+
+  public async run(): Promise<unknown> {
+    const { args, flags } = await this.parse(ProjectMetadata);
+    const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
+    const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
+    const projectId = parseHash(args.ID);
+    const tx = await projects.populateTransaction.setProjectMetadata(projectId, args.METADATA);
+    const output = await run(tx, signer, [projects]);
+    this.log(pretty(output));
+    return output;
+  }
+}

--- a/src/commands/project/metadata.ts
+++ b/src/commands/project/metadata.ts
@@ -10,7 +10,7 @@ export default class ProjectMetadata extends TransactionCommand {
     { name: "ID", description: "The ID of the project to change metadata.", required: true },
     {
       name: "METADATA",
-      description: "Optional JSON.stringified metadata to attach to this project.",
+      description: "New JSON metadata to attach to the project. Previous metadata will be overwritten.",
       required: true,
     },
   ];

--- a/src/commands/project/metadata.ts
+++ b/src/commands/project/metadata.ts
@@ -10,7 +10,7 @@ export default class ProjectMetadata extends TransactionCommand {
     { name: "ID", description: "The ID of the project to change metadata.", required: true },
     {
       name: "METADATA",
-      description: "New JSON metadata to attach to the project. Previous metadata will be overwritten.",
+      description: "New JSON metadata string to attach to the project. Previous metadata will be overwritten.",
       required: true,
     },
   ];
@@ -20,6 +20,12 @@ export default class ProjectMetadata extends TransactionCommand {
     const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const projects = await getContract(flags.network, flags.abi, "ArmadaProjects", signer);
     const projectId = parseHash(args.ID);
+
+    try {
+      JSON.parse(args.METADATA);
+    } catch (e) {
+      this.error("METADATA must be valid JSON.");
+    }
     const tx = await projects.populateTransaction.setProjectMetadata(projectId, args.METADATA);
     const output = await run(tx, signer, [projects]);
     this.log(pretty(output));


### PR DESCRIPTION
Tested locally by updating the ABI and running against staging. i think it's failing because it's trying to parse out the storage structure including metadata, but since it's not there it's throwing an error.

```sh
armada-cli|dm-update-abi-add-project-metadata⚡ ⇒ npm run run -- project list --network=testnet                

> armada-cli@0.3.2 run
> npm run build && ./bin/run project list --network=testnet


> armada-cli@0.3.2 build
> rm -rf ./dist && tsc

    metadata: overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="toNumber", 
    value="27140491875471798111446682089720935113796169662306769464240466418012757426176", code=NUMERIC_FAULT, version=bignumber/5.7.0)
    Code: NUMERIC_FAULT
```

The actual CLI command changes have been tested locally by running a local node, creating a project, updating the metadata and then listing the project details to confirm the changes. Here are the commands

```sh
# assuming `npx hardhat node` is running on another tab

npm run run -- project create --network localhost name email@test.com "" "" '{"key":"value"}'
npm run run -- project list --network localhost
npm run run -- project metadata --network localhost 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563 '{"key":"value2"}'
npm run run -- project list --network localhost
```

