### PR TITLE
Default network to sepolia

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -14,7 +14,7 @@ export abstract class BlockchainCommand extends Command {
       helpGroup: "BASE",
       description: "The network to use.",
       options: NetworkNames,
-      default: "testnet",
+      default: "testnet-sepolia",
     }),
     abi: Flags.string({
       helpGroup: "BASE",


### PR DESCRIPTION
Currently defaults to goerli which is deprecated 12/31/2023. Switch over to sepolia