### PR TITLE
Add flags to delete slot when deleting reservation when admin

### DIFF
--- a/src/commands/reservation/delete.ts
+++ b/src/commands/reservation/delete.ts
@@ -1,3 +1,4 @@
+import { Flags } from "@oclif/core";
 import { Arg } from "@oclif/core/lib/interfaces";
 import { TransactionCommand } from "../../base";
 import { getContract, getSigner, parseHash, pretty, run } from "../../helpers";
@@ -11,6 +12,17 @@ export default class ReservationDelete extends TransactionCommand {
     { name: "ID", description: "The ID of the project to unreserve the nodes.", required: true },
     { name: "IDS", description: "The comma separated IDs of the nodes to unreserve.", required: true },
   ];
+  static flags = {
+    lastSlot: Flags.boolean({
+      description: "[admin only] Delete the reservation from the current epoch instead of the next one.",
+      default: false,
+    }),
+    nextSlotFalse: Flags.boolean({
+      description:
+        "[admin only] If a user has deleted a reservation from next slot but needs admin to run delete for last slot, set this flag so it doesn't encounter node not reserved error.",
+      default: false,
+    }),
+  };
 
   public async run(): Promise<unknown> {
     const { args, flags } = await this.parse(ReservationDelete);
@@ -18,7 +30,7 @@ export default class ReservationDelete extends TransactionCommand {
     const signer = await getSigner(flags.network, flags.rpc, flags.address, flags.signer, flags.key, flags.account);
     const reservations = await getContract(flags.network, flags.abi, "ArmadaReservations", signer);
     const projectId = parseHash(args.ID);
-    const slot = { last: false, next: true };
+    const slot = { last: flags.lastSlot, next: !flags.nextSlotFalse };
     const tx = await reservations.populateTransaction.deleteReservations(projectId, nodeIds, slot);
     const output = await run(tx, signer, [reservations]);
     this.log(pretty(output));


### PR DESCRIPTION
Previously slot was fixed to `{ last: false, next: true }`.

Add two new flags to reservation delete
--lastSlot sets last: true
--nextSlotFalse sets next: false